### PR TITLE
Update salvage-pvc.sh

### DIFF
--- a/salvage-pvc.sh
+++ b/salvage-pvc.sh
@@ -64,9 +64,11 @@ cat <<EOF
 Use:
   kubectl exec -it $pod_name -n $pvc_namespace bash
 Recovered data will be in /salvage
-When you are done, please remove the pod and pvc:
-  kubectl delete -n $pvc_namespace pod/$pod_name pvc/$pvc_name
-Additionally, please clean up the PV when data has been recovered:
+When you are done with the recovery, please remove the salvage pod:
+  kubectl delete -n $pvc_namespace pod/$pod_name
+
+Additionally, please clean up the PVC/PV when data has been recovered and they are no longer needed:
+  kubectl delete -n $pvc_namespace pvc/$pvc_name # Remove this only if your Workspace is no longer needed
   kubectl delete pv $pv_name
 If you wish to keep this PV to rebind later with this script, clear its claim ref:
   kubectl patch pv $pv_name --type=json -p='[{"op": "remove", "path": "/spec/claimRef/uid"}]'


### PR DESCRIPTION
Shifting the delete pvc as it does not apply well in the case of Workspace PVC restoration (like disk full) as we do not want to delete the pvc/pv's at all but go back to our workspace.

Having the delete in a single line is inherently dangerous and likely any user will follow the guide regardless of the use-case or recovery type.